### PR TITLE
fixed "Sec-WebSocket-Accept" response header handling on android

### DIFF
--- a/android/src/com/codebutler/android_websockets/WebSocketClient.java
+++ b/android/src/com/codebutler/android_websockets/WebSocketClient.java
@@ -142,7 +142,7 @@ public class WebSocketClient {
 
                     while (!TextUtils.isEmpty(line = readLine(stream))) {
                         Header header = parseHeader(line);
-                        if (header.getName().equals("Sec-WebSocket-Accept")) {
+                        if (header.getName().toLowerCase().equals("sec-websocket-accept")) {
                             String expected = createSecretValidation(secret);
                             String actual = header.getValue().trim();
 


### PR DESCRIPTION
http header names are case-insensitive and should be handled as such